### PR TITLE
Add UID and GID to set the user & group ID's during runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,16 @@ ENV INGEST_DIR=/cwa-book-ingest
 ENV STATUS_TIMEOUT=3600
 ENV PYTHONPATH=/app
 
-RUN mkdir -p ${INGEST_DIR}
+# Default UID and GID (can be overridden at runtime)
+ENV UID=1000
+ENV GID=100
+
 # Set working directory
 WORKDIR /app
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends --no-install-suggests\
-    calibre p7zip curl \
+RUN apt-get update && apt-get install -y --no-install-recommends --no-install-suggests \
+    calibre p7zip curl gosu \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better caching
@@ -35,7 +38,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-RUN chmod +x /app/check_health.sh
+RUN chmod +x /app/check_health.sh && \
+    chmod +x /app/entrypoint.sh
 
 # Expose port
 EXPOSE ${FLASK_PORT}
@@ -44,5 +48,9 @@ EXPOSE ${FLASK_PORT}
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:${FLASK_PORT}/request/api/status || exit 1
 
+# Entrypoint
+ENTRYPOINT ["/app/entrypoint.sh"]
+
 # Start application
 CMD ["python", "-m", "app"]
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+mkdir -p /var/logs
+mkdir -p "$INGEST_DIR"
+
+# Create group if it doesn't exist
+if ! getent group "$GID" >/dev/null; then
+    groupadd -g "$GID" abc
+fi
+
+# Create user if it doesn't exist
+if ! id -u "$UID" >/dev/null 2>&1; then
+    useradd -u "$UID" -g "$GID" -d /app -s /sbin/nologin abc
+fi
+
+# Adjust ownership of application directories
+chown -R $UID:$GID /app "$INGEST_DIR" /var/logs
+
+# Switch to the created user and execute the main command
+exec gosu $UID "$@"
+

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,8 @@ An intuitive web interface for searching and requesting book downloads, designed
 | `FLASK_DEBUG` | Debug mode toggle | `false` |
 | `FLASK_HOST` | Web interface binding | `0.0.0.0` |
 | `INGEST_DIR` | Book download directory | `/cwa-book-ingest` |
+| `UID` | Runtime user ID | `1000` |
+| `GID` | Runtime group ID | `100` |
 
 #### Download Settings
 | Variable | Description | Default Value |


### PR DESCRIPTION
This PR add the option to set UID/GID during runtime, making sure the application is running as a non-root user.
Besides this, it also helps with making sure UID/GID match between containers.