### PR TITLE
Fix overflow for mobile, add spacing between buttons

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -133,6 +133,7 @@ tbody tr:hover {
     font-size: 1rem;
     transition: background-color 0.3s ease;
     width: 100%;
+    margin-bottom: 0.25rem;
 }
 
 .details-button:hover {
@@ -165,11 +166,11 @@ tbody tr:hover {
 
 .results-content {
     transition: max-height 0.3s ease;
-    overflow: hidden;
 }
 
 .collapsed .results-content {
     max-height: 0;
+    overflow: hidden;
 }
 
 /* Loading Indicator */


### PR DESCRIPTION
Fix mobile being unable to scroll across to the buttons
Retain overflow-hidden when collapsed to hide content

Changing of CSS removes extra margin-bottom: rem padding incidentally