### PR TITLE
Update github action for arm64

### DIFF
--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -35,11 +35,14 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha
             type=ref,event=branch
-            type=ref,event=tag
+            type=ref,event=tag    
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v5
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Suggested changes for updating the github action so it  builds multiplatform -  amd64 & arm64

Following https://docs.docker.com/build/ci/github-actions/multi-platform/

Outside of this branches main objective but thought worth sharing with you @calibrain anyway as this is the last remaining tweak I've needed to build the image 🙂