### PR TITLE
feat: add commit date tagging to Docker image workflow

### DIFF
--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -33,6 +33,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value={{commit_date 'YYYYMMDD'}}
             type=sha
             type=ref,event=branch
             type=ref,event=tag
@@ -44,11 +45,11 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      
+
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
-      
+


### PR DESCRIPTION
This PR adds a date-based tag to the docker container.

Example: 
<img width="875" alt="Screenshot 2025-01-25 at 01 33 01" src="https://github.com/user-attachments/assets/d3c99763-de29-4802-affa-c6fd34f8c611" />

Fixes #68 