### PR TITLE
Enable proxy support via environment variables

### DIFF
--- a/network.py
+++ b/network.py
@@ -80,11 +80,16 @@ def html_get_page_cf(url: str, retry: int = MAX_RETRY) -> str:
         return html_get_page(url, retry, skip_403=True)
     try:
         logger.info(f"GET_CF: {url}")
-        response = requests.get(
-            f"{CLOUDFLARE_PROXY}/html?url={url}&retries=3"
-        )
-        time.sleep(1)
-        return response.text
+        
+        if proxy:
+            response = requests.get(
+                f"{CLOUDFLARE_PROXY}/html?url={url}&proxy={proxy}&retries=3"
+            )
+        else:
+            response = requests.get(
+                f"{CLOUDFLARE_PROXY}/html?url={url}&retries=3"
+            )
+            
         
     except Exception as e:
         if retry == 0:


### PR DESCRIPTION
This update allows users to set the appropriate HTTP_PROXY and HTTPS_PROXY environment variables when starting the Docker container, and all outgoing HTTP/HTTPS requests will automatically use the specified proxy.

This change is particularly beneficial for users in restricted network environments (e.g., China), where access to certain online resources is often blocked.