### PR TITLE
Fix cwa-book-downloader Permission Issues

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,6 +49,7 @@ change_ownership() {
 change_ownership /app
 change_ownership /var/log/cwa-book-downloader
 change_ownership /cwa-book-ingest
+change_ownership /tmp/cwa-book-downloader
 
 # Set the command to run based on the environment
 is_prod=$(echo "$APP_ENV" | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
Fix permission issues that occur if user forgets to create the `cwa-book-downloader` folder before creating the docker container since docker makes the directory with root ownership. 