### PR TITLE
Stop Gunicorn from Giving Up on Slow Tor Requests

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,7 +57,7 @@ change_ownership /tmp/cwa-book-downloader
 # Set the command to run based on the environment
 is_prod=$(echo "$APP_ENV" | tr '[:upper:]' '[:lower:]')
 if [ "$is_prod" = "prod" ]; then 
-    command="gunicorn -b 0.0.0.0:${FLASK_PORT:-8084} app:app"
+    command="gunicorn -t 300 -b 0.0.0.0:${FLASK_PORT:-8084} app:app"
 else
     command="python3 app.py"
 fi


### PR DESCRIPTION
I tried running the docker-compose.yml referenced in this comment https://github.com/calibrain/calibre-web-automated-book-downloader/issues/120#issuecomment-2816539268 from issue #120 and was able to reproduce the same 'Server is not responding' error. I found the issue would happen whenever the captcha bypass took more than 30 seconds due to tor's slower connection. Adding -t 300 would let gunicorn wait up to 5 minutes now.