### PR TITLE
use the FLASK_HOST variable as declared in the documentation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -107,7 +107,7 @@ make_writable /cwa-book-ingest
 # Set the command to run based on the environment
 is_prod=$(echo "$APP_ENV" | tr '[:upper:]' '[:lower:]')
 if [ "$is_prod" = "prod" ]; then 
-    command="gunicorn -t 300 -b 0.0.0.0:${FLASK_PORT:-8084} app:app"
+    command="gunicorn -t 300 -b ${FLASK_HOST:-0.0.0.0}:${FLASK_PORT:-8084} app:app"
 else
     command="python3 app.py"
 fi


### PR DESCRIPTION
I noticed that the FLASK_HOST was not used as stated in the documentation. I need it so that FLASK is listening on my IPv6 address.