### PR TITLE
Rework UI to add inline status

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -533,12 +533,7 @@ h1, h2, h3, h4, h5, h6,
     color: var(--heading-color) !important;
 }
 
-/* Ensure accordion titles are visible */
-.uk-title {
-    color: var(--heading-color) !important;
-}
-
 /* Ensure search results heading is visible */
-#results-section .uk-accordion-title h1 {
+#results-section h1 {
     color: var(--heading-color) !important;
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -534,11 +534,11 @@ h1, h2, h3, h4, h5, h6,
 }
 
 /* Ensure accordion titles are visible */
-.uk-accordion-title {
+.uk-title {
     color: var(--heading-color) !important;
 }
 
 /* Ensure search results heading is visible */
-#results-section-accordion .uk-accordion-title h1 {
+#results-section .uk-accordion-title h1 {
     color: var(--heading-color) !important;
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -368,6 +368,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             return utils.createElement('tr', { id: `row-${book.id}` }, [
                 checkboxCell,
+                utils.createElement('td', { textContent: index + 1 }),
                 this.createPreviewCell(book.preview),
                 utils.createElement('td', { textContent: book.title || 'N/A' }),
                 utils.createElement('td', { textContent: book.author || 'N/A' }),

--- a/templates/index.html
+++ b/templates/index.html
@@ -144,44 +144,40 @@
             </section>
 
             <!-- Results Section -->
-            <ul uk-accordion="animation: false" id="results-section-accordion">
-                <li id="search-accordion">
-                <a class="uk-accordion-title" href><h1 class="uk-heading-xsmall">Search Results</h1></a>
-                <div class="uk-accordion-content">
-                    <div id="search-loading" class="uk-flex uk-flex-center" role="status" hidden>
-                        <div uk-spinner="ratio: 2"></div>
-                        <span>Loading...</span>
-                    </div>
-                    <div class="results-content">
-                    <button class="uk-button uk-button-primary uk-margin-small" id="download-selected-button" disabled>Download Selected</button>
-                        <div class="uk-overflow-auto">
-                            <table id="results-table" class="uk-table uk-table-hover uk-table-divider" role="grid">
-                                <thead>
-                                    <tr>
-                                        <th>
-                                            <input type="checkbox" id="select-all-checkbox" class="uk-checkbox" />
-                                        </th>
-                                        <th scope="col" data-sort="index"># <span class="sort-icon" uk-icon></span></th>
-                                        <th scope="col">Preview</th>
-                                        <th scope="col" data-sort="title">Title <span class="sort-icon" uk-icon></span></th>
-                                        <th scope="col" data-sort="author">Author <span class="sort-icon" uk-icon></span></th>
-                                        <th scope="col" data-sort="publisher">Publisher <span class="sort-icon" uk-icon></span></th>
-                                        <th scope="col" data-sort="year">Year <span class="sort-icon" uk-icon></span></th>
-                                        <th scope="col" data-sort="language">Language <span class="sort-icon" uk-icon></span></th>
-                                        <th scope="col" data-sort="format">Format <span class="sort-icon" uk-icon></span></th>
-                                        <th scope="col" data-sort="size">Size <span class="sort-icon" uk-icon></span></th>
-                                        <th scope="col">Actions</th>
-                                        <th scope="col">Status</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <!-- Search results will be injected here -->
-                                </tbody>
-                            </table>
-                        </div>
+            <ul id="results-section">
+                <h1 class="uk-heading-xsmall">Search Results</h1>
+                <div id="search-loading" class="uk-flex uk-flex-center" role="status" hidden>
+                    <div uk-spinner="ratio: 2"></div>
+                    <span>Loading...</span>
+                </div>
+                <div class="results-content">
+                <button class="uk-button uk-button-primary uk-margin-small" id="download-selected-button" disabled>Download Selected</button>
+                    <div class="uk-overflow-auto">
+                        <table id="results-table" class="uk-table uk-table-hover uk-table-divider" role="grid">
+                            <thead>
+                                <tr>
+                                    <th>
+                                        <input type="checkbox" id="select-all-checkbox" class="uk-checkbox" />
+                                    </th>
+                                    <th scope="col" data-sort="index"># <span class="sort-icon" uk-icon></span></th>
+                                    <th scope="col">Preview</th>
+                                    <th scope="col" data-sort="title">Title <span class="sort-icon" uk-icon></span></th>
+                                    <th scope="col" data-sort="author">Author <span class="sort-icon" uk-icon></span></th>
+                                    <th scope="col" data-sort="publisher">Publisher <span class="sort-icon" uk-icon></span></th>
+                                    <th scope="col" data-sort="year">Year <span class="sort-icon" uk-icon></span></th>
+                                    <th scope="col" data-sort="language">Language <span class="sort-icon" uk-icon></span></th>
+                                    <th scope="col" data-sort="format">Format <span class="sort-icon" uk-icon></span></th>
+                                    <th scope="col" data-sort="size">Size <span class="sort-icon" uk-icon></span></th>
+                                    <th scope="col">Actions</th>
+                                    <th scope="col">Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <!-- Search results will be injected here -->
+                            </tbody>
+                        </table>
                     </div>
                 </div>
-                </li>
             </ul>
 
             <!-- Modal -->
@@ -191,35 +187,7 @@
                 </div>
             </div>
 
-            <!-- Status Section -->
-            <ul uk-accordion="animation: false" id="status-section">
-                <li id="search-accordion">
-                <a class="uk-accordion-title" href><h1 class="uk-heading-xsmall">Download Status</h1></a>
-                <div class="uk-accordion-content">
-                    <div id="status-loading" class="uk-flex uk-flex-center" role="status" hidden>
-                        <div uk-spinner="ratio: 2"></div>
-                        <span>Loading...</span>
-                    </div>
-                    <div class="status-content">
-                        <div class="uk-overflow-auto">
-                            <table id="status-table" class="uk-table uk-table-hover uk-table-divider" role="grid">
-                                <thead>
-                                    <tr>
-                                        <th scope="col">Status</th>
-                                        <th scope="col">Book ID</th>
-                                        <th scope="col">Title</th>
-                                        <th scope="col">Preview</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <!-- Search results will be injected here -->
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                </div>
-                </li>
-            </ul>
+            
         </div>
     </main>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -161,6 +161,7 @@
                                         <th>
                                             <input type="checkbox" id="select-all-checkbox" class="uk-checkbox" />
                                         </th>
+                                        <th scope="col" data-sort="index"># <span class="sort-icon" uk-icon></span></th>
                                         <th scope="col">Preview</th>
                                         <th scope="col" data-sort="title">Title <span class="sort-icon" uk-icon></span></th>
                                         <th scope="col" data-sort="author">Author <span class="sort-icon" uk-icon></span></th>

--- a/templates/index.html
+++ b/templates/index.html
@@ -161,7 +161,6 @@
                                         <th>
                                             <input type="checkbox" id="select-all-checkbox" class="uk-checkbox" />
                                         </th>
-                                        <th scope="col" data-sort="index"># <span class="sort-icon" uk-icon></span></th>
                                         <th scope="col">Preview</th>
                                         <th scope="col" data-sort="title">Title <span class="sort-icon" uk-icon></span></th>
                                         <th scope="col" data-sort="author">Author <span class="sort-icon" uk-icon></span></th>
@@ -171,6 +170,7 @@
                                         <th scope="col" data-sort="format">Format <span class="sort-icon" uk-icon></span></th>
                                         <th scope="col" data-sort="size">Size <span class="sort-icon" uk-icon></span></th>
                                         <th scope="col">Actions</th>
+                                        <th scope="col">Status</th>
                                     </tr>
                                 </thead>
                                 <tbody>


### PR DESCRIPTION
# Summary

This PR reworks the UI to merge the search and downloads sections. 
- Each row now has a "status" column. This column is empty until an entry is downloaded. the download button is disabled until the file has finished downloading.
- removed separate download section
- removed Accordion div for search section

## Examples
<img width="326" height="407" alt="Screenshot from 2025-08-23 15-37-07" src="https://github.com/user-attachments/assets/663fb7cb-0571-40a9-87fc-6849bbd1ce77" />
<img width="289" height="601" alt="Screenshot from 2025-08-23 15-27-49" src="https://github.com/user-attachments/assets/52613ac9-c184-4b8c-98c0-949ff3da1c57" />

## Notes
- I did not include the book ID in the status column, as I don't really know how useful that is to the average user and it would make the column quite large.
- I'm not sure if there is a reason the download button should be re-enabled if the book successfully downloaded. I left it as is for now, but wanted to get some thoughts on this.




