### PR TITLE
feat: Supporting rar/zip books

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,9 @@ RUN apt-get update && \
     # For debug
     zip iputils-ping \
     # For user switching
-    sudo && \
+    sudo \
+    # For rar support
+    unrar && \
     # Cleanup APT cache *after* all installs in this layer
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
     apt-get clean && \

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -6,3 +6,4 @@ dnspython
 gunicorn
 psutil
 emoji
+rarfile


### PR DESCRIPTION
This pull request adds support for handling `.rar` archive files in the book ingestion workflow. It updates the Docker environment to include the necessary utilities, ensures the required Python package is installed, and adds logic to extract both `.zip` and `.rar` files when encountered during book downloads.

**Archive extraction support:**

* Added logic to `_download_book_with_cancellation` in `backend.py` to detect `.zip` and `.rar` files, extract their contents using the appropriate library (`zipfile` for zip, `rarfile` for rar), and clean up the original archive after extraction.

**Dependency and environment updates:**

* Added the `rarfile` Python package to `requirements-base.txt` to enable handling of `.rar` files.
* Updated the `Dockerfile` to install the `unrar` utility, which is required by the `rarfile` library for extracting `.rar` files.