### PR TITLE
Remove deprecated /request route prefix support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ EXPOSE ${FLASK_PORT}
 # Add healthcheck for container status
 # This will run as root initially, but check localhost which should work if the app binds correctly.
 HEALTHCHECK --interval=60s --timeout=60s --start-period=60s --retries=3 \
-    CMD curl -s http://localhost:${FLASK_PORT}/request/api/status > /dev/null || exit 1
+    CMD curl -s http://localhost:${FLASK_PORT}/api/status > /dev/null || exit 1
 
 # Use dumb-init as the entrypoint to handle signals properly
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/readme.md
+++ b/readme.md
@@ -275,7 +275,7 @@ Checks run every 30 seconds with a 30-second timeout and 3 retries.
 You can enable by adding this to your compose :
 ```
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-    CMD pyrequests http://localhost:8084/request/api/status || exit 1
+    CMD curl -s http://localhost:8084/api/status || exit 1
 ```
 
 ## 📝 Logging

--- a/src/README.md
+++ b/src/README.md
@@ -69,8 +69,8 @@ The development server supports HMR for instant feedback during development.
 
 ### API Integration
 The frontend communicates with the Flask backend via:
-- REST API endpoints (`/request/api/*`)
-- WebSocket connection (`ws://localhost:8084/request/ws`)
+- REST API endpoints (`/api/*`)
+- WebSocket connection (`ws://localhost:8084/ws`)
 
 ### Building for Production
 The production build is optimized and minified:

--- a/src/frontend/src/components/DownloadsSidebar.tsx
+++ b/src/frontend/src/components/DownloadsSidebar.tsx
@@ -192,7 +192,7 @@ export const DownloadsSidebar = ({
               <h3 className="font-semibold text-sm truncate" title={book.title}>
                 {isCompleted && book.download_path ? (
                   <a
-                    href={`/request/api/localdownload?id=${encodeURIComponent(book.id)}`}
+                    href={`/api/localdownload?id=${encodeURIComponent(book.id)}`}
                     className="text-sky-600 hover:underline"
                   >
                     {book.title || 'Unknown Title'}

--- a/src/frontend/src/components/Header.tsx
+++ b/src/frontend/src/components/Header.tsx
@@ -277,7 +277,7 @@ export const Header = ({
               {/* Debug Buttons */}
               {debug && (
                 <>
-                  <form action="/request/debug" method="get" className="w-full">
+                  <form action="/debug" method="get" className="w-full">
                     <button
                       className="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-3 text-orange-600 dark:text-orange-400"
                       type="submit"
@@ -288,7 +288,7 @@ export const Header = ({
                       <span>Debug</span>
                     </button>
                   </form>
-                  <form action="/request/api/restart" method="get" className="w-full">
+                  <form action="/api/restart" method="get" className="w-full">
                     <button
                       className="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-3 text-orange-600 dark:text-orange-400"
                       type="submit"

--- a/src/frontend/src/components/StatusSection.tsx
+++ b/src/frontend/src/components/StatusSection.tsx
@@ -114,7 +114,7 @@ export const StatusSection = ({
           {Object.values(items).map((book: any) => {
             const maybeLinkedTitle = book.download_path ? (
               <a
-                href={`/request/api/localdownload?id=${encodeURIComponent(book.id)}`}
+                href={`/api/localdownload?id=${encodeURIComponent(book.id)}`}
                 className="text-blue-600 hover:underline"
               >
                 {book.title || '-'}

--- a/src/frontend/src/services/api.ts
+++ b/src/frontend/src/services/api.ts
@@ -1,6 +1,6 @@
 import { Book, StatusData, AppConfig, LoginCredentials, AuthResponse } from '../types';
 
-const API_BASE = '/request/api';
+const API_BASE = '/api';
 
 // API endpoints
 const API = {

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -16,12 +16,6 @@ export default defineConfig({
     cors: true,
     proxy: {
       // Proxy API requests to the Docker backend
-      '/request/api': {
-        target: 'http://localhost:8084',
-        changeOrigin: true,
-        secure: false,
-      },
-      // Also proxy direct API calls (without /request prefix)
       '/api': {
         target: 'http://localhost:8084',
         changeOrigin: true,

--- a/testing/E2E_test.py
+++ b/testing/E2E_test.py
@@ -124,7 +124,7 @@ print(f"Verified file exists: {expected_filepath}")
 
 # Step 6 : Download the book
 print(f"Step 6: Downloading book {book_id}...")
-download_response = requests.get(f"{server_url}/request/api/localdownload?id={book_id}")
+download_response = requests.get(f"{server_url}/api/localdownload?id={book_id}")
 download_response.raise_for_status()
 # Write book to temp file :
 temp_file_path = os.path.join("/tmp", f"{book_id}.epub")


### PR DESCRIPTION
This commit removes all references to the deprecated /request route prefix
that was previously used for dual routing. The following changes were made:

- Removed register_dual_routes() function that registered routes with /request prefix
- Removed url_for_with_request() helper function for generating /request URLs
- Removed call to register_dual_routes(app) at application startup
- Removed /request/ prefixed favicon routes
- Updated StatusEndpointFilter to remove /request/api/status log filtering
- Removed unused flask_url_for import

All routes now only use the standard paths without the /request prefix.
