### PR TITLE
Fixes default authentication in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,4 +27,4 @@ services:
       - /tmp/data/calibre-web/ingest:/cwa-book-ingest
       # This is the location of CWA's app.db, which contains authentication
       # details. Comment out to disable authentication
-      #- /cwa/config/path/app.db:/auth/app.db:ro
+      #- /cwa/config/path/app.db:/auth:ro


### PR DESCRIPTION
The current docker compose does not allow for authentication & provides a less than clear error (`CWA_DB_PATH is set to /auth/app.db but this is not a valid path`).