### PR TITLE
fix: update auth priority and fallback logic

### DIFF
--- a/cwa_book_downloader/main.py
+++ b/cwa_book_downloader/main.py
@@ -138,28 +138,30 @@ def clear_failed_logins(username: str) -> None:
 def get_auth_mode() -> str:
     """Determine which authentication mode is active.
 
-    Priority order:
-    1. Built-in credentials (if configured) -> "builtin"
-    2. CWA database (if CWA_DB_PATH is set and exists) -> "cwa"
-    3. No auth required -> "none"
+    Priority: 
+    1. Explicit CWA
+    2. Built-in
+    3. Implicit CWA (fallback)
+    4. No auth required -> "none"
     """
     from cwa_book_downloader.core.settings_registry import load_config_file
 
-    # Check for built-in credentials first (they take priority)
     try:
         security_config = load_config_file("security")
-        username = security_config.get("BUILTIN_USERNAME")
-        password_hash = security_config.get("BUILTIN_PASSWORD_HASH")
-        if username and password_hash:
+        # 1. Check for explicit CWA auth
+        if security_config.get("USE_CWA_AUTH") and CWA_DB_PATH and os.path.isfile(CWA_DB_PATH):
+            return "cwa"
+        # 2. Check for built-in credentials
+        if security_config.get("BUILTIN_USERNAME") and security_config.get("BUILTIN_PASSWORD_HASH"):
             return "builtin"
+        # 3. Implicit CWA fallback (config loaded but empty)
+        if CWA_DB_PATH and os.path.isfile(CWA_DB_PATH):
+            return "cwa"
     except Exception:
-        pass  # If config can't be loaded, fall through to other methods
+        # Error fallback: use CWA if available
+        if CWA_DB_PATH and os.path.isfile(CWA_DB_PATH):
+            return "cwa"
 
-    # Check for CWA database
-    if CWA_DB_PATH and os.path.isfile(CWA_DB_PATH):
-        return "cwa"
-
-    # No auth configured
     return "none"
 
 


### PR DESCRIPTION
Reordered the auth priority because the old logic was pretty misleading. It would automatically default to "builtin" mode if credentials existed, completely ignoring the CWA database even if you wanted to use it. You wouldn't even notice it failed to switch until you realized the DB integration wasn't actually active. This fix ensures explicit CWA auth takes priority so you don't have to guess which method is being used.
 
 Cheers 
 
 Your Swiss librarian 
