### PR TITLE
Remove .org domain for AA and add alternative domains

### DIFF
--- a/cwa_book_downloader/config/settings.py
+++ b/cwa_book_downloader/config/settings.py
@@ -717,9 +717,10 @@ def download_source_settings():
             description="Primary Anna's Archive mirror to use. 'auto' selects automatically.",
             options=[
                 {"value": "auto", "label": "Auto (Recommended)"},
-                {"value": "https://annas-archive.org", "label": "annas-archive.org"},
                 {"value": "https://annas-archive.se", "label": "annas-archive.se"},
                 {"value": "https://annas-archive.li", "label": "annas-archive.li"},
+                {"value": "https://annas-archive.pm", "label": "annas-archive.pm"},
+                {"value": "https://annas-archive.in", "label": "annas-archive.in"},
             ],
             default="auto",
         ),

--- a/cwa_book_downloader/download/network.py
+++ b/cwa_book_downloader/download/network.py
@@ -656,7 +656,7 @@ def rotate_dns_and_reset_aa() -> bool:
     configured_url = app_config.get("AA_BASE_URL", "auto")
     if configured_url == "auto" or _aa_base_url in _aa_urls:
         _current_aa_url_index = 0
-        _aa_base_url = _aa_urls[0] if _aa_urls else "https://annas-archive.org"
+        _aa_base_url = _aa_urls[0] if _aa_urls else "https://annas-archive.se"
         logger.info(f"After DNS switch, resetting AA URL to: {_aa_base_url}")
         _save_state(aa_url=_aa_base_url)
     return True
@@ -812,7 +812,7 @@ def _looks_like_ip(s: str) -> bool:
 
 def _build_aa_urls() -> List[str]:
     """Build list of available AA URLs from config."""
-    urls = ["https://annas-archive.org", "https://annas-archive.se", "https://annas-archive.li"]
+    urls = ["https://annas-archive.se", "https://annas-archive.li", "https://annas-archive.pm", "https://annas-archive.in"]
     additional = app_config.get("AA_ADDITIONAL_URLS", "")
     if additional:
         urls.extend(u.strip() for u in additional.split(",") if u.strip())


### PR DESCRIPTION
Anna's Archive main domain, `.org` was seized.
Removing it from choice list and adding official alternatives
More details : https://torrentfreak.com/annas-archive-loses-org-domain-after-surprise-suspension/