### PR TITLE
Fix: Use info hash for clients

### DIFF
--- a/shelfmark/release_sources/prowlarr/clients/deluge.py
+++ b/shelfmark/release_sources/prowlarr/clients/deluge.py
@@ -202,13 +202,20 @@ class DelugeClient(DownloadClient):
             self._connected = False
             return False, f"Connection failed: {str(e)}"
 
-    def add_download(self, url: str, name: str, category: Optional[str] = None) -> str:
+    def add_download(
+        self,
+        url: str,
+        name: str,
+        category: Optional[str] = None,
+        expected_hash: Optional[str] = None,
+        **kwargs,
+    ) -> str:
         try:
             self._ensure_connected()
 
             category_value = str(category or self._category)
 
-            torrent_info = extract_torrent_info(url)
+            torrent_info = extract_torrent_info(url, expected_hash=expected_hash)
             if not torrent_info.is_magnet and not torrent_info.torrent_data:
                 raise Exception("Failed to fetch torrent file")
 

--- a/shelfmark/release_sources/prowlarr/clients/nzbget.py
+++ b/shelfmark/release_sources/prowlarr/clients/nzbget.py
@@ -101,7 +101,14 @@ class NZBGetClient(DownloadClient):
         except Exception as e:
             return False, f"Connection failed: {str(e)}"
 
-    def add_download(self, url: str, name: str, category: Optional[str] = None) -> str:
+    def add_download(
+        self,
+        url: str,
+        name: str,
+        category: Optional[str] = None,
+        expected_hash: Optional[str] = None,
+        **kwargs,
+    ) -> str:
         """
         Add NZB by URL.
 
@@ -112,6 +119,7 @@ class NZBGetClient(DownloadClient):
             url: NZB URL (can be Prowlarr proxy URL)
             name: Display name for the download
             category: Category for organization (uses configured default if not specified)
+            expected_hash: Optional info_hash hint (unused)
 
         Returns:
             NZBGet download ID (NZBID).

--- a/shelfmark/release_sources/prowlarr/clients/qbittorrent.py
+++ b/shelfmark/release_sources/prowlarr/clients/qbittorrent.py
@@ -229,7 +229,14 @@ class QBittorrentClient(DownloadClient):
         except Exception as e:
             return False, f"Connection failed: {str(e)}"
 
-    def add_download(self, url: str, name: str, category: str | None = None) -> str:
+    def add_download(
+        self,
+        url: str,
+        name: str,
+        category: str | None = None,
+        expected_hash: str | None = None,
+        **kwargs,
+    ) -> str:
         """
         Add torrent by URL (magnet or .torrent).
 
@@ -237,6 +244,7 @@ class QBittorrentClient(DownloadClient):
             url: Magnet link or .torrent URL
             name: Display name for the torrent
             category: Category for organization (uses configured default if not specified)
+            expected_hash: Optional info_hash hint (from Prowlarr)
 
         Returns:
             Torrent hash (info_hash).
@@ -257,7 +265,7 @@ class QBittorrentClient(DownloadClient):
                 if "Conflict" not in type(e).__name__ and "409" not in str(e):
                     logger.debug(f"Could not create category '{category}': {type(e).__name__}: {e}")
 
-            torrent_info = extract_torrent_info(url)
+            torrent_info = extract_torrent_info(url, expected_hash=expected_hash)
             expected_hash = torrent_info.info_hash
             torrent_data = torrent_info.torrent_data
 

--- a/shelfmark/release_sources/prowlarr/clients/rtorrent.py
+++ b/shelfmark/release_sources/prowlarr/clients/rtorrent.py
@@ -69,7 +69,14 @@ class RTorrentClient(DownloadClient):
         except Exception as e:
             return False, f"Connection failed: {str(e)}"
 
-    def add_download(self, url: str, name: str, category: Optional[str] = None) -> str:
+    def add_download(
+        self,
+        url: str,
+        name: str,
+        category: Optional[str] = None,
+        expected_hash: Optional[str] = None,
+        **kwargs,
+    ) -> str:
         """
         Add torrent by URL (magnet or .torrent).
 
@@ -77,6 +84,7 @@ class RTorrentClient(DownloadClient):
             url: Magnet link or .torrent URL
             name: Display name for the torrent
             category: Category for organization (uses configured label if not specified)
+            expected_hash: Optional info_hash hint (from Prowlarr)
 
         Returns:
             Torrent hash (info_hash).
@@ -85,7 +93,7 @@ class RTorrentClient(DownloadClient):
             Exception: If adding fails.
         """
         try:
-            torrent_info = extract_torrent_info(url)
+            torrent_info = extract_torrent_info(url, expected_hash=expected_hash)
 
             commands = []
 
@@ -109,7 +117,7 @@ class RTorrentClient(DownloadClient):
                 add_url = torrent_info.magnet_url or url
                 self._rpc.load.start("", add_url, ";".join(commands))
 
-            torrent_hash = torrent_info.info_hash
+            torrent_hash = torrent_info.info_hash or expected_hash
             if not torrent_hash:
                 raise Exception("Could not determine torrent hash from URL")
 

--- a/shelfmark/release_sources/prowlarr/clients/sabnzbd.py
+++ b/shelfmark/release_sources/prowlarr/clients/sabnzbd.py
@@ -172,7 +172,14 @@ class SABnzbdClient(DownloadClient):
         except Exception as e:
             return False, f"Connection failed: {str(e)}"
 
-    def add_download(self, url: str, name: str, category: Optional[str] = None) -> str:
+    def add_download(
+        self,
+        url: str,
+        name: str,
+        category: Optional[str] = None,
+        expected_hash: Optional[str] = None,
+        **kwargs,
+    ) -> str:
         """
         Add NZB by URL.
 
@@ -180,6 +187,7 @@ class SABnzbdClient(DownloadClient):
             url: NZB URL (can be Prowlarr proxy URL)
             name: Display name for the download
             category: Category for organization (uses configured default if not specified)
+            expected_hash: Optional info_hash hint (unused)
 
         Returns:
             SABnzbd nzo_id.

--- a/shelfmark/release_sources/prowlarr/clients/transmission.py
+++ b/shelfmark/release_sources/prowlarr/clients/transmission.py
@@ -73,7 +73,14 @@ class TransmissionClient(DownloadClient):
         except Exception as e:
             return False, f"Connection failed: {str(e)}"
 
-    def add_download(self, url: str, name: str, category: Optional[str] = None) -> str:
+    def add_download(
+        self,
+        url: str,
+        name: str,
+        category: Optional[str] = None,
+        expected_hash: Optional[str] = None,
+        **kwargs,
+    ) -> str:
         """
         Add torrent by URL (magnet or .torrent).
 
@@ -81,6 +88,7 @@ class TransmissionClient(DownloadClient):
             url: Magnet link or .torrent URL
             name: Display name for the torrent
             category: Category for organization (uses configured default if not specified)
+            expected_hash: Optional info_hash hint (from Prowlarr)
 
         Returns:
             Torrent hash (info_hash).
@@ -91,7 +99,7 @@ class TransmissionClient(DownloadClient):
         try:
             resolved_category = category or self._category or ""
 
-            torrent_info = extract_torrent_info(url)
+            torrent_info = extract_torrent_info(url, expected_hash=expected_hash)
 
             if torrent_info.torrent_data:
                 torrent = self._client.add_torrent(

--- a/shelfmark/release_sources/prowlarr/handler.py
+++ b/shelfmark/release_sources/prowlarr/handler.py
@@ -300,10 +300,12 @@ class ProwlarrHandler(DownloadHandler):
                 try:
                     release_name = prowlarr_result.get("title") or task.title or "Unknown"
                     category = self._get_category_for_task(client, task)
+                    expected_hash = str(prowlarr_result.get("infoHash") or "").strip() or None
                     download_id = client.add_download(
                         url=download_url,
                         name=release_name,
                         category=category,
+                        expected_hash=expected_hash,
                     )
                 except Exception as e:
                     logger.error(f"Failed to add to {client.name}: {e}")

--- a/tests/prowlarr/test_clients.py
+++ b/tests/prowlarr/test_clients.py
@@ -151,7 +151,7 @@ class TestDownloadStatus:
             file_path=None,
         )
         with pytest.raises(AttributeError):
-            status.progress = 75.0
+            setattr(status, "progress", 75.0)
 
     def test_download_status_state_value_with_unknown_string(self):
         """Test state_value with an unknown state string."""
@@ -212,7 +212,7 @@ class TestClientRegistry:
             def test_connection(self):
                 return True, "OK"
 
-            def add_download(self, url, name, category="test"):
+            def add_download(self, url, name, category=None, expected_hash=None, **kwargs):
                 return "id"
 
             def get_status(self, download_id):
@@ -245,7 +245,7 @@ class TestClientRegistry:
             def test_connection(self):
                 return True, "OK"
 
-            def add_download(self, url, name, category="test"):
+            def add_download(self, url, name, category=None, expected_hash=None, **kwargs):
                 return "id"
 
             def get_status(self, download_id):
@@ -269,7 +269,7 @@ class TestClientRegistry:
             def test_connection(self):
                 return True, "OK"
 
-            def add_download(self, url, name, category="test"):
+            def add_download(self, url, name, category=None, expected_hash=None, **kwargs):
                 return "id"
 
             def get_status(self, download_id):
@@ -301,7 +301,7 @@ class TestClientRegistry:
             def test_connection(self):
                 return True, "OK"
 
-            def add_download(self, url, name, category="test"):
+            def add_download(self, url, name, category=None, expected_hash=None, **kwargs):
                 return "id"
 
             def get_status(self, download_id):
@@ -325,7 +325,7 @@ class TestClientRegistry:
             def test_connection(self):
                 return True, "OK"
 
-            def add_download(self, url, name, category="test"):
+            def add_download(self, url, name, category=None, expected_hash=None, **kwargs):
                 return "id"
 
             def get_status(self, download_id):
@@ -377,7 +377,7 @@ class TestDownloadClientInterface:
             def test_connection(self):
                 return True, "OK"
 
-            def add_download(self, url, name, category="test"):
+            def add_download(self, url, name, category=None, expected_hash=None, **kwargs):
                 return "id"
 
             def get_status(self, download_id):

--- a/tests/prowlarr/test_failure_scenarios.py
+++ b/tests/prowlarr/test_failure_scenarios.py
@@ -82,7 +82,14 @@ class MockClient(DownloadClient):
     def test_connection(self) -> Tuple[bool, str]:
         return True, "Mock client connected"
 
-    def add_download(self, url: str, name: str, category: str = "cwabd") -> str:
+    def add_download(
+        self,
+        url: str,
+        name: str,
+        category: Optional[str] = None,
+        expected_hash: Optional[str] = None,
+        **kwargs,
+    ) -> str:
         if self.add_download_error:
             raise self.add_download_error
         download_id = f"mock-{len(self.downloads)}"

--- a/tests/prowlarr/test_integration_clients.py
+++ b/tests/prowlarr/test_integration_clients.py
@@ -395,8 +395,9 @@ class TestQBittorrentIntegration:
 
             assert 0 <= status.progress <= 100
 
-            valid_states = {"downloading", "complete", "error", "seeding", "paused", "queued", "fetching_metadata", "stalled"}
-            assert status.state.value in valid_states
+            valid_states = {"downloading", "complete", "error", "seeding", "paused", "queued", "fetching_metadata", "stalled", "checking"}
+            state_value = status.state.value if hasattr(status.state, "value") else status.state
+            assert state_value in valid_states
 
             assert isinstance(status.complete, bool)
         finally:


### PR DESCRIPTION
Passes prowlarr's info hash to download client, existing behavior as fallback