### PR TITLE
fix(search): include default language in search query filters

### DIFF
--- a/shelfmark/release_sources/direct_download.py
+++ b/shelfmark/release_sources/direct_download.py
@@ -164,8 +164,8 @@ def search_books(query: str, filters: SearchFilters) -> List[BookInfo]:
 
     filters_query = ""
 
-    for value in filters.lang if filters.lang is not None else config.BOOK_LANGUAGE:
-        if value != "all":
+    for value in filters.lang if filters.lang else config.BOOK_LANGUAGE or []:
+        if value and value != "all":
             filters_query += f"&lang={quote(value)}"
 
     if filters.sort and filters.sort != "relevance":


### PR DESCRIPTION
## Bug description

When a default language was configured, it was **not passed as a search filter**.  
This occurred regardless of configuration via UI or environment variables.

## Fix

Updated filter logic so that the default language is always applied when no explicit filter is provided:

```python
for value in filters.lang if filters.lang else config.BOOK_LANGUAGE or []:
    if value and value != "all":
        filters_query += f"&lang={quote(value)}"
```

This ensures:
- the default language is used when available
- empty or invalid values are ignored
- "all" does not apply a language filter

## Testing
- default language via UI → search filters correctly
- default language via environment variable → search filters correctly
- "all" value → no language filter applied