### PR TITLE
Switch dev builds to nightly schedule

### DIFF
--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -1,10 +1,12 @@
 name: Create and publish Docker images
 on:
   push:
-    branches:
-      - 'main'
     tags:
       - 'v*'
+  schedule:
+    # Nightly at 03:17 UTC — only builds if there are new commits on main
+    # since the last successful run (see check-changes job).
+    - cron: '17 3 * * *'
   workflow_dispatch:
 permissions: read-all
 
@@ -12,7 +14,41 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/shelfmark
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.check.outputs.should_build }}
+    steps:
+      - name: Check for new commits since last successful build
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          CURRENT_SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Always build on tag pushes and manual dispatch.
+          if [[ "$EVENT_NAME" != "schedule" ]]; then
+            echo "Event is $EVENT_NAME — building unconditionally."
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Scheduled run: only build if HEAD differs from the last successful build on main.
+          LAST_SHA=$(gh api "/repos/${REPO}/actions/workflows/build-and-publish-docker-image.yml/runs?branch=main&status=success&per_page=1" --jq '.workflow_runs[0].head_sha' 2>/dev/null || true)
+          echo "Last successful build SHA: ${LAST_SHA:-<none>}"
+          echo "Current HEAD SHA:          ${CURRENT_SHA}"
+          if [[ -z "$LAST_SHA" || "$LAST_SHA" != "$CURRENT_SHA" ]]; then
+            echo "New commits detected — building."
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No new commits since last successful build — skipping."
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-and-push-images:
+    needs: check-changes
+    if: needs.check-changes.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,26 @@ jobs:
       - name: Run tests
         run: uv run pytest tests/ -x --tb=short
 
+  docker-build-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build shelfmark-lite image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          target: shelfmark-lite
+          platforms: linux/amd64
+          push: false
+          build-args: |
+            BUILD_VERSION=pr-${{ github.sha }}
+            RELEASE_VERSION=pr-${{ github.event.pull_request.number }}
+
   frontend-checks:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
- `dev` images generated on a nightly schedule if new commits exist
- lite container smoke test added to PR CI checks